### PR TITLE
Branding: use "Aspire" instead of ".NET Aspire"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
         }
     },
 
-	// Workarounds to run .NET Aspire in CodeSpaces until future support is added
+	// Workarounds to run Aspire in CodeSpaces until future support is added
 	"containerEnv": {
 		"ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
 		"DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS ": "true"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chat Application using Azure OpenAI, Microsoft.Extensions.AI, and .NET Aspire (C#/.NET)
+# Chat Application using Azure OpenAI, Microsoft.Extensions.AI, and Aspire (C#/.NET)
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Azure-Samples/ai-chat-aspire-meai-csharp)
 [![Open in Dev Containers](https://img.shields.io/static/v1?style=for-the-badge&label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/azure-samples/ai-chat-aspire-meai-csharp)
@@ -27,7 +27,7 @@ since the local app needs credentials for Azure OpenAI to work properly.
 
 * An [ASP.NET Core](https://dotnet.microsoft.com/en-us/apps/aspnet) that uses the [Microsoft.Extensions.AI](https://devblogs.microsoft.com/dotnet/introducing-microsoft-extensions-ai-preview/) package to access language models to generate responses to user messages.
 * A Blazor frontend that streams responses from the backend.
-* [.NET Aspire](https://learn.microsoft.com/dotnet/aspire/get-started/aspire-overview) to orchestrate and build a cloud native application.
+* [Aspire](https://learn.microsoft.com/dotnet/aspire/get-started/aspire-overview) to orchestrate and build a cloud native application.
 * [Bicep files](https://docs.microsoft.com/azure/azure-resource-manager/bicep/) for provisioning Azure resources, including Azure OpenAI, Azure Container Apps, Azure Container Registry, Azure Log Analytics, and RBAC roles.
 * Using the OpenAI gpt-4o model through Azure OpenAI.
 
@@ -136,7 +136,7 @@ If using the command line, run the following from the `src` directory:
     dotnet run
     ```
 
-In the Debug Console (or Terminal window) that appears, you'll see status messages written as the .NET Aspire application starts up. When it's finished starting, look for the text that says something like `Login to the dashboard at https://localhost:17099/login?t=8e08b4369732034c8d67dc80f54fa1db`. Copy the text after "t=" - in this example you'd copy the text "8e08b4369732034c8d67dc80f54fa1db" this is a token you'll use to login to the .NET Aspire Dashboard. Then, click on the https://localhost:17099 URL, paste the token you just copied, and login.
+In the Debug Console (or Terminal window) that appears, you'll see status messages written as the Aspire application starts up. When it's finished starting, look for the text that says something like `Login to the dashboard at https://localhost:17099/login?t=8e08b4369732034c8d67dc80f54fa1db`. Copy the text after "t=" - in this example you'd copy the text "8e08b4369732034c8d67dc80f54fa1db" this is a token you'll use to login to the Aspire Dashboard. Then, click on the https://localhost:17099 URL, paste the token you just copied, and login.
 
 Finally, in the dashboard that appears you'll see the aichatapp-web resource listed. Click on the URL under the Endpoints column to launch the web application and try the chat experience.
 
@@ -179,7 +179,7 @@ You may want to consider additional security measures, such as:
 
 ## Resources
 
-* [eShopSupport .NET Aspire + AI sample](https://github.com/dotnet/eShopSupport/): A full featured .NET Aspire application using AI
+* [eShopSupport Aspire + AI sample](https://github.com/dotnet/eShopSupport/): A full featured Aspire application using AI
 * [Develop .NET Apps with AI Features](https://learn.microsoft.com/dotnet/ai/get-started/dotnet-ai-overview)
-* [.NET Aspire Overview](https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview)
+* [Aspire Overview](https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview)
 * [Overview of Microsoft.Extensions.AI](https://devblogs.microsoft.com/dotnet/introducing-microsoft-extensions-ai-preview/)

--- a/docs/get-started-codespaces.md
+++ b/docs/get-started-codespaces.md
@@ -47,7 +47,7 @@ If using the command line, run the following from the `src` directory:
     dotnet run
     ```
 
-In the Debug Console (or Terminal window) that appears, you'll see status messages written as the .NET Aspire application starts up. When it's finished starting, look for the text that says something like `Login to the dashboard at https://localhost:17099/login?t=8e08b4369732034c8d67dc80f54fa1db`. Copy the text after "t=" - in this example you'd copy the text "8e08b4369732034c8d67dc80f54fa1db" this is a token you'll use to login to the .NET Aspire Dashboard. Then, click on the https://localhost:17099 URL, paste the token you just copied, and login.
+In the Debug Console (or Terminal window) that appears, you'll see status messages written as the Aspire application starts up. When it's finished starting, look for the text that says something like `Login to the dashboard at https://localhost:17099/login?t=8e08b4369732034c8d67dc80f54fa1db`. Copy the text after "t=" - in this example you'd copy the text "8e08b4369732034c8d67dc80f54fa1db" this is a token you'll use to login to the Aspire Dashboard. Then, click on the https://localhost:17099 URL, paste the token you just copied, and login.
 
 Finally, in the dashboard that appears you'll see the aichatapp-web resource listed. Click on the URL under the Endpoints column to launch the web application and try the chat experience.
 

--- a/src/AIChatApp.AppHost/AIChatApp.AppHost.csproj
+++ b/src/AIChatApp.AppHost/AIChatApp.AppHost.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
@@ -9,8 +9,8 @@
     <UserSecretsId>83f75567-5b61-466c-83a3-fc927eb7ac45</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
-    <PackageReference Include="Aspire.Hosting.Azure.CognitiveServices" Version="9.0.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure.CognitiveServices" Version="13.4.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AIChatApp.Web\AIChatApp.Web.csproj" />

--- a/src/AIChatApp.AppHost/Program.cs
+++ b/src/AIChatApp.AppHost/Program.cs
@@ -28,7 +28,7 @@ builder.AddProject<AIChatApp_Web>("aichatapp-web")
 
 builder.Build().Run();
 
-// WORKAROUND: Enables GitHub Codespaces when running in that environment. This will be fixed in a future .NET Aspire release.
+// WORKAROUND: Enables GitHub Codespaces when running in that environment. This will be fixed in a future Aspire release.
 public static class CodespaceExtensions
 {
     public static IDistributedApplicationBuilder WithCodespacesSupport(this IDistributedApplicationBuilder builder)

--- a/src/AIChatApp.ServiceDefaults/Extensions.cs
+++ b/src/AIChatApp.ServiceDefaults/Extensions.cs
@@ -9,7 +9,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions


### PR DESCRIPTION
## Use "Aspire" branding and update to the latest release (13.4.6)

Aspire was rebranded from **".NET Aspire"** to simply **"Aspire"**, and the latest release is **13.4.6** ([aspire.dev](https://aspire.dev)). This PR updates this sample accordingly.

### Branding
- Replaced `.NET Aspire` → `Aspire` in prose/docs.
- **Left unchanged** references tied to a specific older release (e.g. ".NET Aspire 9.4", ".NET Aspire 8.0"), since that was the product name at that version. Historical notes/changelogs are also untouched. `ASP.NET` text is unaffected.

### Versions
- Bumped official `Aspire.*` packages and `Aspire.AppHost.Sdk` to **13.4.6**.
- Left as-is: AI integration packages (`Aspire.Azure.AI.OpenAI`, `Aspire.Azure.AI.Inference`) — no stable 13.x exists and the preview build requires a newer runtime than this sample targets; `Aspire.Hosting.NodeJs` (no 13.x release); `CommunityToolkit.Aspire.*` (separate versioning).

> Opened as a **draft** for maintainer review. A cross-major bump may require small code adjustments to build — please validate. Part of a coordinated branding + version refresh.
